### PR TITLE
Fixes runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.2.1",
     "moment": "^2.11.2",
     "prop-types": "^15.5.10",
-    "react": "^16.0.0-alpha.6",
+    "react": "16.0.0-alpha.6",
     "react-native": "^0.44.3",
     "react-native-device-info": "^0.10.2",
     "react-native-dialogs": "0.0.19",


### PR DESCRIPTION
Fixes runtime error: "error: bundling: UnableToResolveError: Unable to resolve module `react/lib/ReactComponentTreeHook`"